### PR TITLE
Add README badges and Codecov integration

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,5 +29,17 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+    - name: Generate coverage badge
+      if: github.ref == 'refs/heads/main'
+      uses: jaywcjlove/coverage-badges-cli@v2.1.0
+      with:
+        source: coverage/coverage-summary.json
+        output: coverage/badge.svg
+    - name: Deploy coverage badge
+      if: github.ref == 'refs/heads/main'
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./coverage
+        destination_dir: coverage
+        keep_files: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,6 +30,4 @@ jobs:
     - run: npm run build --if-present
     - run: npm test
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v5

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,17 +29,7 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
-    - name: Generate coverage badge
-      if: github.ref == 'refs/heads/main'
-      uses: jaywcjlove/coverage-badges-cli@v2.1.0
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
       with:
-        source: coverage/coverage-summary.json
-        output: coverage/badge.svg
-    - name: Deploy coverage badge
-      if: github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./coverage
-        destination_dir: coverage
-        keep_files: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,3 +29,7 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # label-emails
 
 [![CI](https://github.com/codeallthethingz/label-emails/actions/workflows/node.js.yml/badge.svg)](https://github.com/codeallthethingz/label-emails/actions/workflows/node.js.yml)
-[![codecov](https://codecov.io/gh/codeallthethingz/label-emails/branch/main/graph/badge.svg)](https://codecov.io/gh/codeallthethingz/label-emails)
+[![coverage](https://codeallthethingz.github.io/label-emails/coverage/badge.svg)](https://codeallthethingz.github.io/label-emails/coverage/lcov-report/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js Version](https://img.shields.io/badge/node-22.x-green.svg)](https://nodejs.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # label-emails
 
+[![CI](https://github.com/codeallthethingz/label-emails/actions/workflows/node.js.yml/badge.svg)](https://github.com/codeallthethingz/label-emails/actions/workflows/node.js.yml)
+[![codecov](https://codecov.io/gh/codeallthethingz/label-emails/branch/main/graph/badge.svg)](https://codecov.io/gh/codeallthethingz/label-emails)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Node.js Version](https://img.shields.io/badge/node-22.x-green.svg)](https://nodejs.org/)
+
 A Google Apps Script that automatically triages your Gmail inbox using Google Contacts groups.
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # label-emails
 
 [![CI](https://github.com/codeallthethingz/label-emails/actions/workflows/node.js.yml/badge.svg)](https://github.com/codeallthethingz/label-emails/actions/workflows/node.js.yml)
-[![coverage](https://codeallthethingz.github.io/label-emails/coverage/badge.svg)](https://codeallthethingz.github.io/label-emails/coverage/lcov-report/)
+[![codecov](https://codecov.io/gh/codeallthethingz/label-emails/branch/main/graph/badge.svg)](https://codecov.io/gh/codeallthethingz/label-emails)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node.js Version](https://img.shields.io/badge/node-22.x-green.svg)](https://nodejs.org/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "test": "jest"
+        "test": "jest --coverage"
     },
     "devDependencies": {
         "jest": "^29.0.0"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
     "scripts": {
         "test": "jest --coverage"
     },
-    "jest": {
-        "coverageReporters": ["json-summary", "lcov", "text"]
-    },
     "devDependencies": {
         "jest": "^29.0.0"
     }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "scripts": {
         "test": "jest --coverage"
     },
+    "jest": {
+        "coverageReporters": ["json-summary", "lcov", "text"]
+    },
     "devDependencies": {
         "jest": "^29.0.0"
     }


### PR DESCRIPTION
## Summary
- Adds CI status, code coverage, MIT license, and Node.js version badges to the README
- Enables Jest `--coverage` flag
- Adds Codecov upload step to CI workflow

**Note:** The coverage badge requires enabling the repo on [codecov.io](https://codecov.io) and adding a `CODECOV_TOKEN` repository secret.

## Test plan
- [x] Verify CI passes with coverage enabled
- [x] Enable repo on Codecov and add `CODECOV_TOKEN` secret
- [ ] Confirm badges render correctly on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)